### PR TITLE
Initial Setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: java
 env:
   global:
+    - BAZEL_INSTALL="${HOME}/bazel/install"
+  matrix:
     - BAZEL_VERSION=0.5.4
     - BAZEL_VERSION=0.6.0
     - BAZEL_VERSION=0.6.1
-    - BAZEL_INSTALL="${HOME}/bazel/install"
 install:
   - mkdir -p $BAZEL_INSTALL
   - pushd $BAZEL_INSTALL

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # bazel-scala-test
 
-Validate issues with test-dependencies using: https://github.com/bazelbuild/rules_scala
+Repo to validate issues with test-dependencies using: https://github.com/bazelbuild/rules_scala
+
+At this point in time the repo is working fine:
+
+* Building a `scala_library`
+* Using `scala_library` as a dependency to `scala_test`
+* Running under Bazel `0.5.4`, `0.6.0`, and `0.6.1`

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 git_repository(
     name = "io_bazel_rules_scala",
     remote = "https://github.com/bazelbuild/rules_scala.git",
-    commit = "0bac7fe86fdde1cfba3bb2c8a04de5e12de47bcd",
+    commit = "7b9b89b70bfd6935ccfc9886105471ba4b733fd1",
 )
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()


### PR DESCRIPTION
Ensure we can build under multiple Bazel versions and use latest `rules_scala`.