### PR TITLE
Attempt to use an External Dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,3 +5,9 @@ git_repository(
 )
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()
+
+maven_jar(
+    name = "org_scala_lang_scala_parser_combinators",
+    artifact = "org.scala-lang:scala-parser-combinators:2.11.0-M4",
+    sha1 = "25b3a88078544a2b9e11b999e5d689cb73d9c0ea",
+)

--- a/src/main/scala/Sample/BUILD
+++ b/src/main/scala/Sample/BUILD
@@ -7,3 +7,11 @@ scala_library(
     srcs = ["A.scala"],
     deps = [],
 )
+
+scala_library(
+    name = "simple_parser",
+    srcs = ["SimpleParser.scala"],
+    deps = [
+        "@org_scala_lang_scala_parser_combinators//jar"
+    ],
+)

--- a/src/main/scala/Sample/SimpleParser.scala
+++ b/src/main/scala/Sample/SimpleParser.scala
@@ -1,0 +1,7 @@
+package Sample
+
+import scala.util.parsing.combinator._
+
+object SimpleParser extends RegexParsers {
+  def word: Parser[String] = """[a-z]+""".r ^^ { _.toString }
+}

--- a/src/test/scala/Sample/BUILD
+++ b/src/test/scala/Sample/BUILD
@@ -17,5 +17,6 @@ scala_test(
     srcs = ["SimpleParserTest.scala"],
     deps = [
         "//src/main/scala/Sample:simple_parser",
+        "@org_scala_lang_scala_parser_combinators//jar",
     ],
 )

--- a/src/test/scala/Sample/BUILD
+++ b/src/test/scala/Sample/BUILD
@@ -10,3 +10,12 @@ scala_test(
         "//src/main/scala/Sample:a"
     ],
 )
+
+scala_test(
+    name = "simple_parser_test",
+    size = "small",
+    srcs = ["SimpleParserTest.scala"],
+    deps = [
+        "//src/main/scala/Sample:simple_parser",
+    ],
+)

--- a/src/test/scala/Sample/SimpleParserTest.scala
+++ b/src/test/scala/Sample/SimpleParserTest.scala
@@ -1,0 +1,9 @@
+package Sample
+
+import org.scalatest.FunSuite
+
+class SimpleParserTest extends FunSuite {
+  test("Attempt to run a .parse with our Parser") {
+    SimpleParser.parse(SimpleParser.word, "johnny come lately")
+  }
+}


### PR DESCRIPTION
We currently have a working build for `scala_library` and `scala_test` targets. This PR will illustrate how the new `SimpleParser` main class external dependencies are not used for `scala_test` targets.


cef927d:

* Import `org_scala_lang_scala_parser_combinators`
* Add a SimpleParser example for `scala.util.parsing.combinator._`

6b27703:
* Add the external dependency to the `scala_test` target and see it succeed.
